### PR TITLE
Update to bevy 0.14

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_fundsp"
 authors = ["Gio Genre De Asis"]
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 description = "A Bevy plugin that integrates FunDSP into Bevy."
 homepage = "https://github.com/harudagondi/bevy_fundsp"
@@ -15,14 +15,13 @@ categories = ["game-development", "multimedia::audio"]
 [features]
 default = ["bevy_audio"]
 kira = ["dep:kira", "bevy_kira_audio"]
-bevy_audio = ["bevy/bevy_audio", "bevy/wav", "rodio"]
+bevy_audio = ["bevy/bevy_audio", "bevy/wav"]
 oddio = ["bevy_oddio"]
 
 [dependencies]
-fundsp = "0.15"
+fundsp = "0.18"
 cpal = "0.15"
 once_cell = "1.13"
-rodio = { version = "0.17.1", default-features = false, features = ["wav"], optional = true }
 kira = { version = "0.8", default-features = false, features = ["wav"], optional = true }
 
 [dependencies.uuid]
@@ -33,14 +32,14 @@ features = [
 
 [dependencies.bevy]
 # git = "https://github.com/bevyengine/bevy"
-version = "0.11"
+version = "0.14"
 default-features = false 
 features = ["bevy_asset"]
 
 [dependencies.bevy_kira_audio]
 # git = "https://github.com/NiklasEi/bevy_kira_audio.git"
 # branch = "bevy_main"
-version = "0.16"
+version = "0.20"
 default-features = false
 features = ["wav"]
 optional = true
@@ -55,7 +54,7 @@ features = ["wav"]
 
 [dev-dependencies.bevy]
 # git = "https://github.com/bevyengine/bevy"
-version = "0.11"
+version = "0.14"
 default-features = false
 features = [
   "bevy_core_pipeline",
@@ -70,7 +69,8 @@ features = [
   "bevy_gilrs",
   "png",
   "hdr",
-  "filesystem_watcher",
+  "file_watcher",
+  "multi_threaded",
   "x11"
 ]
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ fn main() {
         .run();
 }
 
-fn white_noise() -> impl AudioUnit32 {
+fn white_noise() -> impl AudioUnit {
     white() >> split::<U2>() * 0.2
 }
 

--- a/examples/bevy_audio/interactive.rs
+++ b/examples/bevy_audio/interactive.rs
@@ -13,12 +13,12 @@ fn main() {
         .run();
 }
 
-fn sine_wave() -> impl AudioUnit32 {
+fn sine_wave() -> impl AudioUnit {
     // Note is A4
     sine_hz(440.0) >> split::<U2>() * 0.2
 }
 
-fn triangle_wave() -> impl AudioUnit32 {
+fn triangle_wave() -> impl AudioUnit {
     // Note is G4
     triangle_hz(392.0) >> split::<U2>() * 0.2
 }
@@ -57,14 +57,14 @@ fn setup(
     ));
 }
 
-fn interactive_audio(input: Res<Input<KeyCode>>, mut query: Query<(&mut AudioSink, &Dsp)>) {
-    if input.just_pressed(KeyCode::S) {
+fn interactive_audio(input: Res<ButtonInput<KeyCode>>, mut query: Query<(&mut AudioSink, &Dsp)>) {
+    if input.just_pressed(KeyCode::KeyS) {
         for (sink, _) in query.iter_mut().filter(|(_s, d)| **d == Dsp::Sine) {
             sink.toggle();
         }
     }
 
-    if input.just_pressed(KeyCode::T) {
+    if input.just_pressed(KeyCode::KeyT) {
         for (sink, _) in query.iter_mut().filter(|(_s, d)| **d == Dsp::Triangle) {
             sink.toggle();
         }

--- a/examples/bevy_audio/noise.rs
+++ b/examples/bevy_audio/noise.rs
@@ -11,7 +11,7 @@ fn main() {
         .run();
 }
 
-fn white_noise() -> impl AudioUnit32 {
+fn white_noise() -> impl AudioUnit {
     white() >> split::<U2>() * 0.2
 }
 

--- a/examples/bevy_audio/pitch.rs
+++ b/examples/bevy_audio/pitch.rs
@@ -14,12 +14,12 @@ struct PianoPlugin;
 
 struct PianoDsp<F>(F);
 
-impl<T: AudioUnit32 + 'static, F: Send + Sync + 'static + Fn() -> T> DspGraph for PianoDsp<F> {
+impl<T: AudioUnit + 'static, F: Send + Sync + 'static + Fn() -> T> DspGraph for PianoDsp<F> {
     fn id(&self) -> Uuid {
         Uuid::from_u128(0xa1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8u128)
     }
 
-    fn generate_graph(&self) -> Box<dyn AudioUnit32> {
+    fn generate_graph(&self) -> Box<dyn AudioUnit> {
         Box::new((self.0)())
     }
 }
@@ -28,7 +28,7 @@ impl<T: AudioUnit32 + 'static, F: Send + Sync + 'static + Fn() -> T> DspGraph fo
 struct PianoId(Uuid);
 
 #[derive(Resource)]
-struct PitchVar(Shared<f32>);
+struct PitchVar(Shared);
 
 impl PitchVar {
     fn set_pitch(&self, pitch: Pitch) {
@@ -94,25 +94,25 @@ impl Plugin for PianoPlugin {
     }
 }
 
-fn switch_key(input: Res<Input<KeyCode>>, pitch_var: Res<PitchVar>) {
+fn switch_key(input: Res<ButtonInput<KeyCode>>, pitch_var: Res<PitchVar>) {
     let keypress = |keycode, pitch| {
         if input.just_pressed(keycode) {
             pitch_var.set_pitch(pitch)
         }
     };
 
-    keypress(KeyCode::A, Pitch::C);
-    keypress(KeyCode::W, Pitch::Cs);
-    keypress(KeyCode::S, Pitch::D);
-    keypress(KeyCode::E, Pitch::Ds);
-    keypress(KeyCode::D, Pitch::E);
-    keypress(KeyCode::F, Pitch::F);
-    keypress(KeyCode::T, Pitch::Fs);
-    keypress(KeyCode::G, Pitch::G);
-    keypress(KeyCode::Y, Pitch::Gs);
-    keypress(KeyCode::H, Pitch::A);
-    keypress(KeyCode::U, Pitch::As);
-    keypress(KeyCode::J, Pitch::B);
+    keypress(KeyCode::KeyA, Pitch::C);
+    keypress(KeyCode::KeyW, Pitch::Cs);
+    keypress(KeyCode::KeyS, Pitch::D);
+    keypress(KeyCode::KeyE, Pitch::Ds);
+    keypress(KeyCode::KeyD, Pitch::E);
+    keypress(KeyCode::KeyF, Pitch::F);
+    keypress(KeyCode::KeyT, Pitch::Fs);
+    keypress(KeyCode::KeyG, Pitch::G);
+    keypress(KeyCode::KeyY, Pitch::Gs);
+    keypress(KeyCode::KeyH, Pitch::A);
+    keypress(KeyCode::KeyU, Pitch::As);
+    keypress(KeyCode::KeyJ, Pitch::B);
 }
 
 fn play_piano(

--- a/examples/kira/interactive.rs
+++ b/examples/kira/interactive.rs
@@ -13,23 +13,23 @@ fn main() {
         .run();
 }
 
-fn sine_wave() -> impl AudioUnit32 {
+fn sine_wave() -> impl AudioUnit {
     // Note is A4
     sine_hz(440.0) >> split::<U2>() * 0.2
 }
 
-fn triangle_wave() -> impl AudioUnit32 {
+fn triangle_wave() -> impl AudioUnit {
     // Note is G4
     triangle_hz(392.0) >> split::<U2>() * 0.2
 }
 
 fn interactive_audio(
-    input: Res<Input<KeyCode>>,
+    input: Res<ButtonInput<KeyCode>>,
     mut assets: ResMut<Assets<AudioSource>>,
     dsp_manager: Res<DspManager>,
     audio: ResMut<Audio>,
 ) {
-    if input.just_pressed(KeyCode::S) {
+    if input.just_pressed(KeyCode::KeyS) {
         let source = dsp_manager
             .get_graph(sine_wave)
             .unwrap_or_else(|| panic!("DSP source not found!"));
@@ -38,7 +38,7 @@ fn interactive_audio(
         audio.play(audio_source);
     }
 
-    if input.just_pressed(KeyCode::T) {
+    if input.just_pressed(KeyCode::KeyT) {
         let source = dsp_manager
             .get_graph(triangle_wave)
             .unwrap_or_else(|| panic!("DSP source not found!"));

--- a/examples/kira/noise.rs
+++ b/examples/kira/noise.rs
@@ -12,7 +12,7 @@ fn main() {
         .run();
 }
 
-fn white_noise() -> impl AudioUnit32 {
+fn white_noise() -> impl AudioUnit {
     white() >> split::<U2>() * 0.2
 }
 

--- a/src/backend/bevy_audio.rs
+++ b/src/backend/bevy_audio.rs
@@ -22,7 +22,7 @@ impl Decodable for DspSource {
     }
 }
 
-impl rodio::Source for IterMono {
+impl bevy::audio::Source for IterMono {
     fn current_frame_len(&self) -> Option<usize> {
         None
     }

--- a/src/dsp_graph.rs
+++ b/src/dsp_graph.rs
@@ -1,6 +1,6 @@
 //! Module for the [`DspGraph`] trait.
 
-use {fundsp::prelude::AudioUnit32, uuid::Uuid};
+use {fundsp::prelude::AudioUnit, uuid::Uuid};
 
 /// Trait for generating DSP sources.
 ///
@@ -23,20 +23,20 @@ pub trait DspGraph: Send + Sync + 'static {
     fn id(&self) -> Uuid;
 
     /// Generate a DSP graph.
-    fn generate_graph(&self) -> Box<dyn AudioUnit32>;
+    fn generate_graph(&self) -> Box<dyn AudioUnit>;
 }
 
 impl<F, Au> DspGraph for F
 where
     F: Send + Sync + 'static + Fn() -> Au,
-    Au: AudioUnit32 + 'static,
+    Au: AudioUnit + 'static,
 {
     fn id(&self) -> Uuid {
         // TODO: This should be based on its `TypeId`
         Uuid::new_v5(&Uuid::NAMESPACE_OID, std::any::type_name::<F>().as_bytes())
     }
 
-    fn generate_graph(&self) -> Box<dyn AudioUnit32> {
+    fn generate_graph(&self) -> Box<dyn AudioUnit> {
         Box::new(self())
     }
 }

--- a/src/dsp_source.rs
+++ b/src/dsp_source.rs
@@ -3,8 +3,8 @@
 
 use {
     crate::dsp_graph::DspGraph,
-    bevy::reflect::{TypePath, TypeUuid},
-    fundsp::{hacker32::AudioUnit32, wave::Wave32},
+    bevy::{asset::Asset, reflect::TypePath},
+    fundsp::{hacker32::AudioUnit, wave::Wave},
     std::{cell::RefCell, sync::Arc},
 };
 
@@ -12,8 +12,7 @@ use {
 ///
 /// These can be played directly when the [`SourceType`] is dynamic,
 /// otherwise, the DSP source must be played with a given duration.
-#[derive(TypeUuid, Clone, TypePath)]
-#[uuid = "107a9069-d37d-46a8-92f2-23ec23b73bf6"]
+#[derive(Clone, TypePath, Asset)]
 pub struct DspSource {
     pub(crate) dsp_graph: Arc<dyn DspGraph>,
     pub(crate) sample_rate: f32,
@@ -71,7 +70,7 @@ impl DspSource {
 
         let mut node = self.dsp_graph.generate_graph();
 
-        let wave = Wave32::render(
+        let wave = Wave::render(
             f64::from(self.sample_rate),
             f64::from(duration),
             node.as_mut(),
@@ -104,7 +103,7 @@ impl IntoIterator for DspSource {
 /// This is infinite, and would never return `None`.
 pub struct Iter {
     pub(crate) sample_rate: f32,
-    pub(crate) audio_unit: RefCell<Box<dyn AudioUnit32>>,
+    pub(crate) audio_unit: RefCell<Box<dyn AudioUnit>>,
 }
 
 pub(crate) trait Source {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,10 @@
 
 use {
     backend::{Backend, DefaultBackend},
-    bevy::prelude::{AddAsset, App, Plugin},
+    bevy::{
+        asset::AssetApp,
+        prelude::{App, Plugin},
+    },
     dsp_graph::DspGraph,
     dsp_manager::DspManager,
     dsp_source::{DspSource, SourceType},
@@ -50,8 +53,8 @@ pub mod dsp_source;
 /// # use bevy_fundsp::prelude::*;
 /// App::new()
 ///     .add_plugins(DefaultPlugins)
-///     .add_plugin(DspPlugin::default())
-///     .run()
+///     .add_plugins(DspPlugin::default())
+///     .run();
 /// ```
 pub struct DspPlugin {
     sample_rate: f32,
@@ -71,8 +74,8 @@ impl DspPlugin {
     /// # use bevy_fundsp::prelude::*;
     /// App::new()
     ///     .add_plugins(DefaultPlugins)
-    ///     .add_plugin(DspPlugin::new(44100.0))
-    ///     .run()
+    ///     .add_plugins(DspPlugin::new(44100.0))
+    ///     .run();
     /// ```
     #[allow(clippy::must_use_candidate)]
     pub fn new(sample_rate: f32) -> Self {
@@ -89,7 +92,7 @@ impl Default for DspPlugin {
 impl Plugin for DspPlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(DspManager::new(self.sample_rate))
-            .add_asset::<DspSource>();
+            .init_asset::<DspSource>();
 
         DefaultBackend::init_app(app);
     }
@@ -106,11 +109,11 @@ pub trait DspAppExt {
     /// # use bevy_fundsp::prelude::*;
     /// App::new()
     ///     .add_plugins(DefaultPlugins)
-    ///     .add_plugin(DspPlugin::default())
+    ///     .add_plugins(DspPlugin::default())
     ///     .add_dsp_source(a_simple_440hz_sine_wave, SourceType::Dynamic)
     ///     .run();
     ///
-    /// fn a_simple_440hz_sine_wave() -> impl AudioUnit32 {
+    /// fn a_simple_440hz_sine_wave() -> impl AudioUnit {
     ///     sine_hz(440.0)
     /// }
     /// ```
@@ -119,7 +122,7 @@ pub trait DspAppExt {
 
 impl DspAppExt for App {
     fn add_dsp_source<D: DspGraph>(&mut self, dsp_graph: D, source_type: SourceType) -> &mut Self {
-        let mut dsp_manager = self.world.resource_mut::<DspManager>();
+        let mut dsp_manager = self.world_mut().resource_mut::<DspManager>();
 
         dsp_manager.add_graph(dsp_graph, source_type);
 


### PR DESCRIPTION
Update bevy_fundsp to bevy 0.14.
PR is very similar to https://github.com/harudagondi/bevy_fundsp/pull/50
One difference is that it seems `rodio` is not needed anymore as it is package by bevy itself now.
the `oddio` feature is broken because the `bevy_oddio` crate needs a version bump too.